### PR TITLE
Add Peru to countrynames

### DIFF
--- a/wlm-stats.py
+++ b/wlm-stats.py
@@ -183,6 +183,7 @@ countrynames = {
     u'pakistan': u'Pakistan', 
     u'palestine': u'Palestine', 
     u'panama': u'Panama', 
+    u'peru': u'Peru', 
     u'philippines': u'Philippines', 
     u'poland': u'Poland', 
     u'portugal': u'Portugal', 


### PR DESCRIPTION
This prevented Peru from showing up in the statistics.

Also checked that Peru was the only one which was missing
